### PR TITLE
RHW-20 | Add unit tests for use-infinite-loader

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -18,8 +18,8 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
 
-      - name: Bootstrap packages
-        run: yarn bootstrap
+      - name: Build packages
+        run: yarn build
 
       - name: Run lint
         run: yarn lint

--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -27,10 +27,13 @@ jobs:
       - name: Run typecheck
         run: yarn typecheck
 
+      - name: Run unit tests
+        run: yarn test --silent
+
       - name: Build Sandbox
         run: yarn sandbox:build
 
-      - name: Run e2e
+      - name: Run e2e tests
         uses: cypress-io/github-action@v2
         with:
           install: false

--- a/packages/use-infinite-loader/src/calc-unloaded-ranges.ts
+++ b/packages/use-infinite-loader/src/calc-unloaded-ranges.ts
@@ -3,11 +3,11 @@ export const calcUnloadedRanges = (
   overscanFromIndex: number,
   overscanBeforeIndex: number
 ): ReadonlyArray<[number, number]> => {
-  const ranges = new Array<[number, number]>(0)
+  const ranges: Array<[number, number]> = []
 
   for (let index = overscanFromIndex; index < overscanBeforeIndex; index++) {
     // skip loaded
-    while (shouldLoad(index)) {
+    while (!shouldLoad(index)) {
       if (++index >= overscanBeforeIndex) {
         return ranges
       }
@@ -16,7 +16,7 @@ export const calcUnloadedRanges = (
     const start = index
 
     // skip unloaded
-    while (!shouldLoad(index)) {
+    while (shouldLoad(index)) {
       if (++index >= overscanBeforeIndex) {
         ranges.push([start, overscanBeforeIndex])
 

--- a/packages/use-infinite-loader/src/calc-unloaded-ranges.ts
+++ b/packages/use-infinite-loader/src/calc-unloaded-ranges.ts
@@ -1,0 +1,31 @@
+export const calcUnloadedRanges = (
+  shouldLoad: (index: number) => boolean,
+  overscanFromIndex: number,
+  overscanBeforeIndex: number
+): ReadonlyArray<[number, number]> => {
+  const ranges = new Array<[number, number]>(0)
+
+  for (let index = overscanFromIndex; index < overscanBeforeIndex; index++) {
+    // skip loaded
+    while (shouldLoad(index)) {
+      if (++index >= overscanBeforeIndex) {
+        return ranges
+      }
+    }
+
+    const start = index
+
+    // skip unloaded
+    while (!shouldLoad(index)) {
+      if (++index >= overscanBeforeIndex) {
+        ranges.push([start, overscanBeforeIndex])
+
+        return ranges
+      }
+    }
+
+    ranges.push([start, index])
+  }
+
+  return ranges
+}

--- a/packages/use-infinite-loader/src/index.ts
+++ b/packages/use-infinite-loader/src/index.ts
@@ -32,27 +32,26 @@ const calcUnloadedRanges = (
   return ranges
 }
 
-// @TODO rename with ListRenderedRange renaming
-export interface LoadMoreItemsOptions {
-  startIndex: number
-  stopIndex: number
-  count: number
+export interface LoadRange {
+  loadFromIndex: number
+  loadBeforeIndex: number
+  loadCount: number
 }
 
 export interface UseInfiniteLoaderOptions {
   isScrolling: boolean
   overscanFromIndex: number
   overscanBeforeIndex: number
-  isItemLoaded(index: number): boolean
-  loadMoreItems(options: LoadMoreItemsOptions): void
+  shouldLoadItem(index: number): boolean
+  loadItemsRange(range: LoadRange): void
 }
 
 export const useInfiniteLoader = ({
   isScrolling,
   overscanFromIndex,
   overscanBeforeIndex,
-  isItemLoaded,
-  loadMoreItems
+  shouldLoadItem,
+  loadItemsRange
 }: UseInfiniteLoaderOptions): void => {
   useEffect(() => {
     if (isScrolling) {
@@ -60,23 +59,23 @@ export const useInfiniteLoader = ({
     }
 
     const ranges = calcUnloadedRanges(
-      isItemLoaded,
+      shouldLoadItem,
       overscanFromIndex,
       overscanBeforeIndex
     )
 
-    for (const [startIndex, stopIndex] of ranges) {
-      loadMoreItems({
-        startIndex,
-        stopIndex,
-        count: stopIndex - startIndex
+    for (const [loadFromIndex, loadBeforeIndex] of ranges) {
+      loadItemsRange({
+        loadFromIndex,
+        loadBeforeIndex,
+        loadCount: loadBeforeIndex - loadFromIndex
       })
     }
   }, [
     isScrolling,
     overscanFromIndex,
     overscanBeforeIndex,
-    isItemLoaded,
-    loadMoreItems
+    shouldLoadItem,
+    loadItemsRange
   ])
 }

--- a/packages/use-infinite-loader/src/index.ts
+++ b/packages/use-infinite-loader/src/index.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { calcUnloadedRanges } from './calc-unloaded-ranges'
 
-export interface LoadRange {
+export interface LoadingItemsRange {
   loadFromIndex: number
   loadBeforeIndex: number
   loadCount: number
@@ -12,7 +12,7 @@ export interface UseInfiniteLoaderOptions {
   overscanFromIndex: number
   overscanBeforeIndex: number
   shouldLoadItem(index: number): boolean
-  loadItemsRange(range: LoadRange): void
+  loadItemsRange(range: LoadingItemsRange): void
 }
 
 export const useInfiniteLoader = ({

--- a/packages/use-infinite-loader/src/index.ts
+++ b/packages/use-infinite-loader/src/index.ts
@@ -1,36 +1,5 @@
 import { useEffect } from 'react'
-
-const calcUnloadedRanges = (
-  isLoaded: (index: number) => boolean,
-  overscanFromIndex: number,
-  overscanBeforeIndex: number
-): ReadonlyArray<[number, number]> => {
-  const ranges = new Array<[number, number]>(0)
-
-  for (let index = overscanFromIndex; index < overscanBeforeIndex; index++) {
-    // skip loaded
-    while (isLoaded(index)) {
-      if (++index >= overscanBeforeIndex) {
-        return ranges
-      }
-    }
-
-    const start = index
-
-    // skip unloaded
-    while (!isLoaded(index)) {
-      if (++index >= overscanBeforeIndex) {
-        ranges.push([start, overscanBeforeIndex])
-
-        return ranges
-      }
-    }
-
-    ranges.push([start, index])
-  }
-
-  return ranges
-}
+import { calcUnloadedRanges } from './calc-unloaded-ranges'
 
 export interface LoadRange {
   loadFromIndex: number

--- a/packages/use-infinite-loader/tests/calc-unloaded-ranges.test.ts
+++ b/packages/use-infinite-loader/tests/calc-unloaded-ranges.test.ts
@@ -4,12 +4,16 @@ test('ranges are empty for invalid overscan indexes', () => {
   expect(calcUnloadedRanges(() => true, 10, 0)).toEqual([])
 })
 
-test('ranges are empty for overscan indexes', () => {
+test('ranges are empty when overscan range is empty', () => {
   expect(calcUnloadedRanges(() => true, 0, 0)).toEqual([])
 })
 
 test('ranges are empty when all items are loaded', () => {
   expect(calcUnloadedRanges(() => false, 0, 10)).toEqual([])
+})
+
+test('ranges are empty when shouldLoad is out of range', () => {
+  expect(calcUnloadedRanges(i => i === 10, 0, 10)).toEqual([])
 })
 
 test('single range when all items are unloaded', () => {

--- a/packages/use-infinite-loader/tests/calc-unloaded-ranges.test.ts
+++ b/packages/use-infinite-loader/tests/calc-unloaded-ranges.test.ts
@@ -1,0 +1,67 @@
+import { calcUnloadedRanges } from '../src/calc-unloaded-ranges'
+
+test('ranges are empty for invalid overscan indexes', () => {
+  expect(calcUnloadedRanges(() => true, 10, 0)).toEqual([])
+})
+
+test('ranges are empty for overscan indexes', () => {
+  expect(calcUnloadedRanges(() => true, 0, 0)).toEqual([])
+})
+
+test('ranges are empty when all items are loaded', () => {
+  expect(calcUnloadedRanges(() => false, 0, 10)).toEqual([])
+})
+
+test('single range when all items are unloaded', () => {
+  expect(calcUnloadedRanges(() => true, 0, 1)).toEqual([[0, 1]])
+  expect(calcUnloadedRanges(() => true, 0, 10)).toEqual([[0, 10]])
+})
+
+test('load a single item', () => {
+  expect(calcUnloadedRanges(i => i === 0, 0, 10)).toEqual([[0, 1]])
+  expect(calcUnloadedRanges(i => i === 3, 0, 10)).toEqual([[3, 4]])
+  expect(calcUnloadedRanges(i => i === 6, 0, 10)).toEqual([[6, 7]])
+  expect(calcUnloadedRanges(i => i === 9, 0, 10)).toEqual([[9, 10]])
+})
+
+test('load chunks', () => {
+  const loaded = new Set<number>()
+  const shouldLoad = (i: number): boolean => !loaded.has(i)
+
+  expect(calcUnloadedRanges(shouldLoad, 0, 10)).toEqual([[0, 10]])
+
+  loaded.add(2).add(3)
+  expect(calcUnloadedRanges(shouldLoad, 0, 10)).toEqual([
+    [0, 2],
+    [4, 10]
+  ])
+
+  loaded.add(5).add(8)
+  expect(calcUnloadedRanges(shouldLoad, 0, 10)).toEqual([
+    [0, 2],
+    [4, 5],
+    [6, 8],
+    [9, 10]
+  ])
+
+  loaded.add(4)
+  expect(calcUnloadedRanges(shouldLoad, 0, 10)).toEqual([
+    [0, 2],
+    [6, 8],
+    [9, 10]
+  ])
+
+  loaded.add(0).add(1)
+  expect(calcUnloadedRanges(shouldLoad, 0, 10)).toEqual([
+    [6, 8],
+    [9, 10]
+  ])
+
+  loaded.add(9)
+  expect(calcUnloadedRanges(shouldLoad, 0, 10)).toEqual([[6, 8]])
+
+  loaded.add(6).add(7)
+  expect(calcUnloadedRanges(shouldLoad, 0, 10)).toEqual([])
+
+  expect(loaded.size).toBe(10)
+})

--- a/packages/use-windowed-list/README.md
+++ b/packages/use-windowed-list/README.md
@@ -387,7 +387,7 @@ A collection of values describing two half-open intervals:
 1. visible items ∈ `[visibleFromIndex, visibleBeforeIndex)` partially or entirely visible on the current scroll position
 1. overscan items ∈ `[overscanFromIndex, overscanBeforeIndex)` includes visible items and some additional non-visible defined via [UseWindowedListOptions.overscanCount][use-windowed-list-options.overscan-count] value.
 
-> 💬 Both intervals include the “from” indexe and exclude “before”. It’s pretty straightforward to know the number of items in a range by subtracting `beforeIndex - fromIndex` or iterate it by <code>for (let i = fromIndex; i < beforeIndex; i++)</code>, for instance:
+> 💬 Both intervals include the “from” indexes and exclude “before”. It’s pretty straightforward to know the number of items in a range by subtracting `beforeIndex - fromIndex` or iterate it by <code>for (let i = fromIndex; i < beforeIndex; i++)</code>, for instance:
 >
 > ```ts
 > const range: ListRenderedRange = {

--- a/sandbox/src/InfiniteLoaderDemo.tsx
+++ b/sandbox/src/InfiniteLoaderDemo.tsx
@@ -68,10 +68,7 @@ const InfiniteRangeLoaderDemo = React.memo(() => {
   const itemSize = 50
   const [items, setItems] = React.useState<Partial<Record<number, string>>>({})
   const [loading, setLoading] = React.useState<Record<number, boolean>>({})
-  const shouldLoadItem = React.useCallback(
-    index => !(index in loading),
-    [loading]
-  )
+  const shouldLoadItem = React.useCallback(index => !loading[index], [loading])
 
   const {
     setRef,

--- a/sandbox/src/InfiniteLoaderDemo.tsx
+++ b/sandbox/src/InfiniteLoaderDemo.tsx
@@ -68,7 +68,10 @@ const InfiniteRangeLoaderDemo = React.memo(() => {
   const itemSize = 50
   const [items, setItems] = React.useState<Partial<Record<number, string>>>({})
   const [loading, setLoading] = React.useState<Record<number, boolean>>({})
-  const isItemLoaded = React.useCallback(index => index in loading, [loading])
+  const shouldLoadItem = React.useCallback(
+    index => !(index in loading),
+    [loading]
+  )
 
   const {
     setRef,
@@ -88,21 +91,21 @@ const InfiniteRangeLoaderDemo = React.memo(() => {
     isScrolling,
     overscanFromIndex,
     overscanBeforeIndex,
-    isItemLoaded,
-    loadMoreItems: React.useCallback(({ startIndex, count }) => {
+    shouldLoadItem,
+    loadItemsRange: React.useCallback(({ loadFromIndex, loadCount }) => {
       const accLoading: Record<number, boolean> = {}
 
-      for (let index = 0; index < count; index++) {
-        accLoading[startIndex + index] = true
+      for (let index = 0; index < loadCount; index++) {
+        accLoading[loadFromIndex + index] = true
       }
 
       setLoading(current => ({ ...current, ...accLoading }))
 
-      loadRange(startIndex, count, 200).then(data => {
+      loadRange(loadFromIndex, loadCount, 200).then(data => {
         const accItems: Record<number, string> = {}
 
         for (let index = 0; index < data.length; index++) {
-          accItems[startIndex + index] = data[index]
+          accItems[loadFromIndex + index] = data[index]
         }
 
         setItems(current => ({ ...current, ...accItems }))
@@ -128,7 +131,10 @@ const InfinitePagedLoaderDemo = React.memo(() => {
   const itemSize = 30
   const pageSize = 10
   const [items, setItems] = React.useState<ReadonlyArray<string>>([])
-  const isItemLoaded = React.useCallback(index => index < items.length, [items])
+  const shouldLoadItem = React.useCallback(
+    (index: number) => index >= items.length,
+    [items]
+  )
 
   const {
     setRef,
@@ -148,8 +154,8 @@ const InfinitePagedLoaderDemo = React.memo(() => {
     isScrolling,
     overscanFromIndex,
     overscanBeforeIndex,
-    isItemLoaded,
-    loadMoreItems: React.useCallback(() => {
+    shouldLoadItem,
+    loadItemsRange: React.useCallback(() => {
       loadRange(items.length, pageSize, 200).then(data => {
         setItems(current => [...current, ...data])
       })
@@ -174,7 +180,10 @@ const UndefinitePagedLoaderDemo = React.memo(() => {
   const itemSize = 30
   const pageSize = 10
   const [items, setItems] = React.useState<ReadonlyArray<string>>([])
-  const isItemLoaded = React.useCallback(index => index < items.length, [items])
+  const shouldLoadItem = React.useCallback(
+    (index: number) => index >= items.length,
+    [items]
+  )
 
   const {
     setRef,
@@ -194,8 +203,8 @@ const UndefinitePagedLoaderDemo = React.memo(() => {
     isScrolling,
     overscanFromIndex,
     overscanBeforeIndex,
-    isItemLoaded,
-    loadMoreItems: React.useCallback(() => {
+    shouldLoadItem,
+    loadItemsRange: React.useCallback(() => {
       loadRange(items.length, pageSize, 200).then(data => {
         setItems(current => [...current, ...data])
       })


### PR DESCRIPTION
affects: @react-hook-window/use-infinite-loader

The changes are targeting both the signature of the `use-infinite-loader` hook and introducing unit tests for loading ranges calculation.

BREAKING CHANGE:
Public API of useInfiniteLoader hook

Closes #20 