### PR TITLE
RHW-24 | rename setRef to setContainerRef

### DIFF
--- a/packages/use-windowed-list/README.md
+++ b/packages/use-windowed-list/README.md
@@ -65,7 +65,7 @@ export const FriendsList: React.VFC<{
   friends: Array<Friend>
 }> = ({ friends }) => {
   // 1. Call the hook
-  const { setRef, startSpace, endSpace, indexes } = useWindowedList({
+  const { setContainerRef, startSpace, endSpace, indexes } = useWindowedList({
     containerSize: FRIENDS_CONTAINER_HEIGHT,
     itemSize: FRIENDS_ITEM_HEIGHT,
     itemCount: friends.length
@@ -74,7 +74,7 @@ export const FriendsList: React.VFC<{
   return (
     <div
       // 2. Set the container ref
-      ref={setRef}
+      ref={setContainerRef}
       className="container"
       style={{
         overflow: 'auto',
@@ -118,7 +118,7 @@ The custom `useWindowedList` hook calculates a visible range of items in a g
 
 Under the hood, the hook calculates a range of visible items based on three variables:
 
-1. **Scrolling position** - the container’s `scrollTop` or `scrollLeft` for vertical or horizontal [layouts][list-layout] respectively, extracted from a container’s node passed via [`UseWindowedListResult.setRef`][use-windowed-list-result.set-ref].
+1. **Scrolling position** - the container’s `scrollTop` or `scrollLeft` for vertical or horizontal [layouts][list-layout] respectively, extracted from a container’s node passed via [`UseWindowedListResult.setContainerRef`][use-windowed-list-result.set-container-ref].
 2. **Container size** - the container’s height or width for vertical or horizontal [layouts][list-layout] respectively, defined via [`UseWindowedListOptions.containerSize`][use-windowed-list-options.container-size].
 3. **Items size** - the items’ height or width for vertical or horizontal [layouts][list-layout] respectively defined via [`UseWindowedListOptions.itemSize`][use-windowed-list-options.item-size].
 
@@ -412,7 +412,7 @@ export interface UseWindowedListResult<E extends HTMLElement>
   indexes: ReadonlyArray<number>
   isScrolling: boolean
   container: null | E
-  setRef: (node: null | E) => void
+  setContainerRef: (node: null | E) => void
   scrollTo: (px: number) => void
   scrollToItem: (index: number, position?: ScrollPosition) => void
 }
@@ -458,15 +458,15 @@ A flag indicates whenever the container is scrolling. See the relevant [`UseWi
 container: null | E
 ```
 
-Either a container’s node extending `HTMLElement` or `null`. The value gets assigned by the [`UseWindowedListResult.setRef`][use-windowed-list-result.set-ref] function.
+Either a container’s node extending `HTMLElement` or `null`. The value gets assigned by the [`UseWindowedListResult.setContainerRef`][use-windowed-list-result.set-container-ref] function.
 
-#### `UseWindowedListResult.setRef`
+#### `UseWindowedListResult.setContainerRef`
 
 ```ts
-setRef: (node: null | E) => void
+setContainerRef: (node: null | E) => void
 ```
 
-A function to set a container `node` of a windowed list. Each call of `setRef` enqueues a re-render of the component. Because of that, the hook always calculates an output with an actual container. The value is accessible via the [`UseWindowedListResult.container`][use-windowed-list-result.container] property.
+A function to set a container `node` of a windowed list. Each call of `setContainerRef` enqueues a re-render of the component. Because of that, the hook always calculates an output with an actual container. The value is accessible via the [`UseWindowedListResult.container`][use-windowed-list-result.container] property.
 
 #### `UseWindowedListResult.scrollTo`
 
@@ -1062,7 +1062,7 @@ A set of available values defining a target element when scrolling via [`UseW
 [use-windowed-list-result.container]: #usewindowedlistresultcontainer
 [use-windowed-list-result.scroll-to]: #usewindowedlistresultscrollto
 [use-windowed-list-result.scroll-to-item]: #usewindowedlistresultscrolltoitem
-[use-windowed-list-result.set-ref]: #usewindowedlistresultsetref
+[use-windowed-list-result.set-container-ref]: #usewindowedlistresultsetcontainerref
 [use-windowed-list-result.is-scrolling]: #usewindowedlistresultisscrolling
 [list-layout]: #type-listlayout
 [scroll-position]: #type-scrollposition

--- a/packages/use-windowed-list/src/use-windowed-list.ts
+++ b/packages/use-windowed-list/src/use-windowed-list.ts
@@ -107,8 +107,6 @@ export type InitialListElementScroll = {
 
 export type InitialListScroll = number | InitialListElementScroll
 
-// @TODO add containerRef as an option
-// @TODO add offset to set a scroll position from which first item starts
 export interface UseWindowedListOptions {
   containerSize: number
   itemSize: ItemSize
@@ -128,8 +126,7 @@ export interface UseWindowedListResult<E extends HTMLElement>
   indexes: ReadonlyArray<number>
   isScrolling: boolean
   container: null | E
-  // @TODO rename to setContainerRef
-  setRef(node: null | E): void
+  setContainerRef(node: null | E): void
   scrollTo(px: number): void
   scrollToItem(index: number, position?: ScrollPosition): void
 }
@@ -275,7 +272,7 @@ export const useWindowedList = <E extends HTMLElement>({
   return {
     container,
     isScrolling,
-    setRef: setContainer,
+    setContainerRef: setContainer,
 
     overscanFromIndex: start,
     overscanBeforeIndex: stop,

--- a/sandbox/src/InfiniteLoaderDemo.tsx
+++ b/sandbox/src/InfiniteLoaderDemo.tsx
@@ -71,7 +71,7 @@ const InfiniteRangeLoaderDemo = React.memo(() => {
   const shouldLoadItem = React.useCallback(index => !loading[index], [loading])
 
   const {
-    setRef,
+    setContainerRef,
     startSpace,
     endSpace,
     indexes,
@@ -112,7 +112,7 @@ const InfiniteRangeLoaderDemo = React.memo(() => {
 
   return (
     <ItemsList
-      ref={setRef}
+      ref={setContainerRef}
       containerSize={containerSize}
       itemSize={itemSize}
       indexes={indexes}
@@ -134,7 +134,7 @@ const InfinitePagedLoaderDemo = React.memo(() => {
   )
 
   const {
-    setRef,
+    setContainerRef,
     startSpace,
     endSpace,
     indexes,
@@ -161,7 +161,7 @@ const InfinitePagedLoaderDemo = React.memo(() => {
 
   return (
     <ItemsList
-      ref={setRef}
+      ref={setContainerRef}
       containerSize={containerSize}
       itemSize={itemSize}
       indexes={indexes}
@@ -183,7 +183,7 @@ const UndefinitePagedLoaderDemo = React.memo(() => {
   )
 
   const {
-    setRef,
+    setContainerRef,
     startSpace,
     endSpace,
     indexes,
@@ -210,7 +210,7 @@ const UndefinitePagedLoaderDemo = React.memo(() => {
 
   return (
     <ItemsList
-      ref={setRef}
+      ref={setContainerRef}
       containerSize={containerSize}
       itemSize={itemSize}
       indexes={indexes}

--- a/sandbox/src/TrelloDemo.tsx
+++ b/sandbox/src/TrelloDemo.tsx
@@ -459,13 +459,14 @@ const ViewWindowedColumn = React.memo<{
   const [getItemSize, setItemSize] = useItemsSize(column?.tickets)
   const [containerHeight, setContainerHeight] = React.useState(0)
 
-  const { container, setRef, indexes, startSpace, endSpace } = useWindowedList({
-    overscanCount: 3,
-    containerSize: containerHeight,
-    itemSize: getItemSize,
-    itemCount: column?.tickets.length ?? 0,
-    initialScroll
-  })
+  const { container, setContainerRef, indexes, startSpace, endSpace } =
+    useWindowedList({
+      overscanCount: 3,
+      containerSize: containerHeight,
+      itemSize: getItemSize,
+      itemCount: column?.tickets.length ?? 0,
+      initialScroll
+    })
 
   useResizeObserver(node => setContainerHeight(node.clientHeight), container)
 
@@ -487,7 +488,7 @@ const ViewWindowedColumn = React.memo<{
     <StyledColumn>
       <div>{column.title}</div>
 
-      <StyledTicketsScroller ref={setRef}>
+      <StyledTicketsScroller ref={setContainerRef}>
         <div style={{ height: startSpace }} />
 
         {indexes.map(index => (
@@ -686,12 +687,13 @@ const ViewWindowedTrello = React.memo<{
 }>(({ flow }) => {
   const [getScrollPosition, setScrollPosition] = useScrollPositions()
   const [containerWidth, setContainerWidth] = React.useState(0)
-  const { container, setRef, indexes, startSpace, endSpace } = useWindowedList({
-    containerSize: containerWidth,
-    itemSize: 300,
-    itemCount: flow.length,
-    layout: 'horizontal'
-  })
+  const { container, setContainerRef, indexes, startSpace, endSpace } =
+    useWindowedList({
+      containerSize: containerWidth,
+      itemSize: 300,
+      itemCount: flow.length,
+      layout: 'horizontal'
+    })
 
   useResizeObserver(
     React.useCallback(node => setContainerWidth(node.clientWidth), []),
@@ -699,7 +701,7 @@ const ViewWindowedTrello = React.memo<{
   )
 
   return (
-    <StyledColumnsScroller ref={setRef}>
+    <StyledColumnsScroller ref={setContainerRef}>
       <div style={{ display: 'inline-block', width: startSpace }} />
 
       {indexes.map(index => (

--- a/sandbox/src/WindowedListDemo.tsx
+++ b/sandbox/src/WindowedListDemo.tsx
@@ -10,7 +10,7 @@ const WindowedList = React.memo<{
   options: ControlPanelOptions
 }>(({ options }) => {
   const {
-    setRef,
+    setContainerRef,
     startSpace,
     endSpace,
     indexes,
@@ -44,7 +44,7 @@ const WindowedList = React.memo<{
 
       <div
         data-testid="container"
-        ref={setRef}
+        ref={setContainerRef}
         style={{
           display: isVertical ? 'block' : 'flex',
           flexDirection: isVertical ? 'unset' : 'row',


### PR DESCRIPTION
affects: @react-hook-window/use-windowed-list, sandbox

BREAKING CHANGE:
Public api of use-windowed-list hook is changed

Closes #24 